### PR TITLE
[EVENT] 아웃박스 메세지 릴레이 적용 1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,9 +33,11 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation("org.springframework.security:spring-security-crypto") // 핵심 암호화 기능만 포함
+	implementation 'org.springframework.kafka:spring-kafka'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/app/slicequeue/sq_user/common/event/Event.java
+++ b/src/main/java/app/slicequeue/sq_user/common/event/Event.java
@@ -1,0 +1,45 @@
+package app.slicequeue.sq_user.common.event;
+
+import app.slicequeue.sq_user.common.util.DataSerializer;
+import lombok.Getter;
+
+/**
+ * 이벤트 통신을 위한 클래스
+ */
+@Getter
+public class Event <T extends EventPayload>{
+    private Long eventId;
+    private EventType type;
+    private T payload;
+
+    public static Event<EventPayload> of(Long eventId, EventType type, EventPayload payload) {
+        Event<EventPayload> event = new Event<>();
+        event.eventId = eventId;
+        event.type = type;
+        event.payload = payload;
+        return event;
+    }
+
+    public String toJson() {
+        return DataSerializer.serialize(this);
+    }
+
+    public static Event<EventPayload> fromJson(String json) {
+        EventRaw eventRaw = DataSerializer.deserialize(json, EventRaw.class);
+        if (eventRaw == null) {
+            return null;
+        }
+        Event<EventPayload> event = new Event<>();
+        event.eventId = eventRaw.getEventId();
+        event.type = EventType.from(eventRaw.getType());
+        event.payload = DataSerializer.deserialize(eventRaw.getPayload(), event.type.getPayloadClass());
+        return event;
+    }
+
+    @Getter
+    public static class EventRaw {
+        private Long eventId;
+        private String type;
+        private Object payload;
+    }
+}

--- a/src/main/java/app/slicequeue/sq_user/common/event/EventPayload.java
+++ b/src/main/java/app/slicequeue/sq_user/common/event/EventPayload.java
@@ -1,0 +1,4 @@
+package app.slicequeue.sq_user.common.event;
+
+public interface EventPayload {
+}

--- a/src/main/java/app/slicequeue/sq_user/common/event/EventType.java
+++ b/src/main/java/app/slicequeue/sq_user/common/event/EventType.java
@@ -1,0 +1,33 @@
+package app.slicequeue.sq_user.common.event;
+
+import app.slicequeue.sq_user.common.event.payload.UserInfoChangedEventPayload;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * 이벤트 통신을 위한 클래스
+ */
+@Log4j2
+@Getter
+@RequiredArgsConstructor
+public enum EventType {
+
+    USER_INFO_CHANGED(UserInfoChangedEventPayload.class, Topic.SQ_USER_INFO_CHANGED);
+
+    private final Class<? extends EventPayload> payloadClass;   // 이 이벤트들이 어떤 페이로드를 가지는지 그 클래스 타입!
+    private final String topic;                                 // 이 이벤트들이 어떤 카프카 토픽으로 전달 될 수 있는지
+
+    public static EventType from(String type) {
+        try {
+            return valueOf(type);
+        } catch (Exception e) {
+            log.error("[EventType.from] type={}", type, e);
+            return null;
+        }
+    }
+
+    public static class Topic {
+        public static final String SQ_USER_INFO_CHANGED = "sq-user-info-changed";
+    }
+}

--- a/src/main/java/app/slicequeue/sq_user/common/event/payload/UserInfoChangedEventPayload.java
+++ b/src/main/java/app/slicequeue/sq_user/common/event/payload/UserInfoChangedEventPayload.java
@@ -1,0 +1,27 @@
+package app.slicequeue.sq_user.common.event.payload;
+
+import app.slicequeue.sq_user.common.event.EventPayload;
+import app.slicequeue.sq_user.user.command.domain.type.UserState;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.Map;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserInfoChangedEventPayload implements EventPayload {
+
+    private long userId;
+    private long projectId;
+    private String loginId;
+    private UserState state;
+    private String nickname;
+    private Map<String, Object> profile;
+    private Instant createdAt;
+    private Instant updatedAt;
+}

--- a/src/main/java/app/slicequeue/sq_user/common/outbox_message/Outbox.java
+++ b/src/main/java/app/slicequeue/sq_user/common/outbox_message/Outbox.java
@@ -1,0 +1,30 @@
+package app.slicequeue.sq_user.common.outbox_message;
+
+import app.slicequeue.sq_user.common.converter.MapToJsonConverter;
+import app.slicequeue.sq_user.common.event.EventType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.Map;
+
+@Table(name = "outbox")
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Outbox {
+
+    @EmbeddedId
+    @AttributeOverride(name = "id", column = @Column(name = "outbox_id"))
+    private OutboxId outboxId;
+    @Enumerated(EnumType.STRING)
+    private EventType eventType;
+    @Convert(converter = MapToJsonConverter.class)
+    @Column(name = "payload_json")
+    private Map<String, Object> payload;
+    private Long targetId;
+    private Instant createdAt;
+
+}

--- a/src/main/java/app/slicequeue/sq_user/common/outbox_message/OutboxId.java
+++ b/src/main/java/app/slicequeue/sq_user/common/outbox_message/OutboxId.java
@@ -1,0 +1,32 @@
+package app.slicequeue.sq_user.common.outbox_message;
+
+import app.slicequeue.common.base.id_entity.BaseSnowflakeId;
+import app.slicequeue.common.snowflake.Snowflake;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OutboxId extends BaseSnowflakeId<OutboxId> {
+
+    static Snowflake snowflake = new Snowflake();
+
+    public OutboxId(Long id) {
+        super(id);
+    }
+
+    @Override
+    protected Snowflake getSnowflake() {
+        return snowflake;
+    }
+
+    public static OutboxId generateId() {
+        return new OutboxId().generate();
+    }
+
+    public static OutboxId from(Long idValue) {
+        return from(idValue, OutboxId.class);
+    }
+}
+

--- a/src/main/java/app/slicequeue/sq_user/common/outbox_relay/AssignedShard.java
+++ b/src/main/java/app/slicequeue/sq_user/common/outbox_relay/AssignedShard.java
@@ -1,0 +1,43 @@
+package app.slicequeue.sq_user.common.outbox_relay;
+
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.LongStream;
+
+/**
+ * AssignedShard 각 인스턴스가 담당할 shard 계산
+ */
+@Getter
+public class AssignedShard {
+
+    private List<Long> shards;
+
+    public static AssignedShard of(String appId, List<String> appIds, long shardCount) {
+        // Redis 기록된 살아있는 앱 ID 리스트를 기준으로
+        // 현재 인스턴스가 담당할 샤드 범위를 계산해서 리턴
+        AssignedShard assignedShard = new AssignedShard();
+        assignedShard.shards = assign(appId, appIds, shardCount);
+        return assignedShard;
+    }
+
+    private static List<Long> assign(String appId, List<String> appIds, long shardCount) {
+        int appIndex = findAppIndex(appId, appIds);
+        if (appIndex == -1) {
+            return List.of();
+        }
+        long start = appIndex * shardCount / appIds.size();
+        long end = (appIndex + 1) * shardCount / appIds.size() - 1;
+
+        return LongStream.rangeClosed(start, end).boxed().toList();
+    }
+
+    private static int findAppIndex(String appId, List<String> appIds) {
+        for (int i = 0; i < appIds.size(); i++) {
+            if (appIds.get(i).equals(appId)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/src/main/java/app/slicequeue/sq_user/common/outbox_relay/MessageRelay.java
+++ b/src/main/java/app/slicequeue/sq_user/common/outbox_relay/MessageRelay.java
@@ -1,0 +1,83 @@
+package app.slicequeue.sq_user.common.outbox_relay;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * 1. MessageRelay — 핵심 이벤트 처리자
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MessageRelay {
+    private final OutboxRepository outboxRepository;
+    private final MessageRelayCoordinator messageRelayCoordinator;  // 살아있는 애플리케이션이 떠있는지 확인할 수 있음
+    private final KafkaTemplate<String, String> messageRelayKafkaTemplate; // MessageRelayConfig 에서 빈 등록한 messageRelayKafkaTemplate 주입하기 위함
+
+    /**
+     * 트랜잭션 커밋 전에 이벤트를 Outbox 테이블에 저장
+     * @param outboxEvent 아웃박스 이벤트
+     */
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void createOutbox(OutboxEvent outboxEvent) {
+        log.info("[MessageRelay.createOutbox] outboxEvent={}", outboxEvent);
+        outboxRepository.save(outboxEvent.getOutbox());
+    }
+
+    /**
+     * 트랜잭션이 커밋된 후에 Kafka 비동기로 메시지를 전송
+     * @param outboxEvent 아웃박스 이벤트
+     */
+    @Async("messageRelayPublishEventExecutor") // MessageRelayConfig 에서 빈 등록한 messageRelayPublishEventExecutor 지정
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void publishEvent(OutboxEvent outboxEvent) {
+        publishEvent(outboxEvent.getOutbox());
+    }
+
+    private void publishEvent(Outbox outbox) {
+        try {
+            messageRelayKafkaTemplate.send(
+                    outbox.getEventType().getTopic(),
+                    String.valueOf(outbox.getShardKey()),
+                    outbox.getPayload()
+            ).get(1, TimeUnit.SECONDS);
+            outboxRepository.delete(outbox); // 전송 성공 시 DB 에서 해당 Outbox 레코드 삭제합니다.
+        } catch (InterruptedException | TimeoutException | ExecutionException e) {
+            log.error("[MessageRelay.publishEvent] outbox={}", outbox, e);
+        }
+    }
+
+    @Scheduled(
+            fixedDelay = 10,
+            initialDelay = 5,
+            timeUnit = TimeUnit.SECONDS,
+            scheduler = "messageRelayPublishPendingEventExecutor"
+    ) // 비동기 전송 실패했다면 일정 시간 지난 Outbox 데이터들을 주기적으로 스캔하여 전송 재시도
+    public void publishPendingEvent() {
+        // "AssignedShard"를 기준으로 자기 인스턴스가 담당해야 할 Shard 의 이벤트만 처리
+        AssignedShard assignedShard = messageRelayCoordinator.assignedShards();
+        log.info("[MessageRelay.publishEvent assignedShared size={}]", assignedShard.getShards().size());
+        for (Long shard : assignedShard.getShards()) {
+            List<Outbox> outboxes =
+                    outboxRepository.findAllByShardKeyAndCreatedAtLessThanEqualOrderByCreatedAtAsc(
+                            shard, LocalDateTime.now().minusSeconds(10), Pageable.ofSize(100));
+            for (Outbox outbox : outboxes) {
+                publishEvent(outbox);
+            }
+        }
+    }
+
+}

--- a/src/main/java/app/slicequeue/sq_user/common/outbox_relay/MessageRelay.java
+++ b/src/main/java/app/slicequeue/sq_user/common/outbox_relay/MessageRelay.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -73,7 +73,7 @@ public class MessageRelay {
         for (Long shard : assignedShard.getShards()) {
             List<Outbox> outboxes =
                     outboxRepository.findAllByShardKeyAndCreatedAtLessThanEqualOrderByCreatedAtAsc(
-                            shard, LocalDateTime.now().minusSeconds(10), Pageable.ofSize(100));
+                            shard, Instant.now().minusSeconds(10), Pageable.ofSize(100));
             for (Outbox outbox : outboxes) {
                 publishEvent(outbox);
             }

--- a/src/main/java/app/slicequeue/sq_user/common/outbox_relay/MessageRelayConfig.java
+++ b/src/main/java/app/slicequeue/sq_user/common/outbox_relay/MessageRelayConfig.java
@@ -1,0 +1,53 @@
+package app.slicequeue.sq_user.common.outbox_relay;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+@EnableAsync
+@Configuration
+@ComponentScan("app.slicequeue.sq_user.common.outbox_relay")
+@EnableScheduling
+public class MessageRelayConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public KafkaTemplate<String, String> messageRelayKafkaTemplate() { // 이벤트 전송 가능하도록
+        Map<String, Object> configProps = new HashMap<>(); // 프로듀서 설정
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers); // 서버 설정 주입받은 것 전달
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);    // 키 직렬화 할떄 문자열
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);  // 값 직렬화 할때 문자열
+        configProps.put(ProducerConfig.ACKS_CONFIG, "all"); // 프로듀서에서는 유실 되는 것을 방지하기 위해 all 로 지정
+        return new KafkaTemplate<>(new DefaultKafkaProducerFactory<>(configProps));
+    }
+
+    @Bean
+    public Executor messageRelayPublishEventExecutor() { // 트렌젝션이 끝날때 마다 비동기로 이벤트 전송할때 사용
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(20);
+        executor.setMaxPoolSize(50);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("mr-pub-event-");
+        return executor;
+    }
+
+    @Bean
+    public Executor messageRelayPublishPendingEventExecutor() {
+        return Executors.newSingleThreadScheduledExecutor(); // 미전송 이벤트들을 전송할때는 싱글 쓰레드에서 작동 처리
+    }
+}

--- a/src/main/java/app/slicequeue/sq_user/common/outbox_relay/MessageRelayConstants.java
+++ b/src/main/java/app/slicequeue/sq_user/common/outbox_relay/MessageRelayConstants.java
@@ -1,0 +1,11 @@
+package app.slicequeue.sq_user.common.outbox_relay;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MessageRelayConstants {
+
+    public static final int SHARD_COUNT = 4; // 샤드 가정 임의의 값
+
+}

--- a/src/main/java/app/slicequeue/sq_user/common/outbox_relay/MessageRelayCoordinator.java
+++ b/src/main/java/app/slicequeue/sq_user/common/outbox_relay/MessageRelayCoordinator.java
@@ -1,0 +1,69 @@
+package app.slicequeue.sq_user.common.outbox_relay;
+
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 2. MessageRelayCoordinator — Redis 인스턴스 관리 & 샤드 분배
+ * - Redis ZSet 구조를 이용해 살아있는 애플리케이션을 주기적으로 ping
+ * - 앱이 죽으면 일정 시간 지나면 자동으로 ZSet 제거
+ * - 이 리스트 기반으로 샤드 분배가 이루어짐
+ */
+@Component
+@RequiredArgsConstructor
+public class MessageRelayCoordinator {
+    private final StringRedisTemplate redisTemplate;
+
+    @Value("${spring.application.name}")
+    private String applicationName;
+
+    // 서버당 UUID 배정
+    private final String APP_ID = UUID.randomUUID().toString();  // 이 값으로 구분
+
+    private final int PING_INTERNAL_SECONDS = 3; // 3초에 한번씩
+    private final int PING_FAILURE_THRESHOLD = 3; // 3번 실패하면 애플리케이션이 죽었다고 판단
+
+    public AssignedShard assignedShards() { // 현재 살아있는 인스턴스 리스트 기준으로 appId → shard 를 분배
+        return AssignedShard.of(APP_ID, findAppIds(), MessageRelayConstants.SHARD_COUNT);
+    }
+
+    private List<String> findAppIds() {
+        return redisTemplate.opsForZSet().reverseRange(generateKey(), 0, -1).stream()
+                .sorted()
+                .toList();
+    }
+
+    @Scheduled(fixedDelay = PING_INTERNAL_SECONDS, timeUnit = TimeUnit.SECONDS)
+    public void ping() { // 현재 앱이 살아있다는 걸 Redis 기록합니다 (ZSet 현재 시간 기준으로 기록)
+        redisTemplate.executePipelined((RedisCallback<?>) action -> {
+            StringRedisConnection conn = (StringRedisConnection) action;
+            String key = generateKey();
+            conn.zAdd(key, Instant.now().toEpochMilli(), APP_ID); // 키값 기준으로 시간 값으로 Z 스코어 값 지정, 그리고 값은 APP_ID
+            conn.zRemRangeByScore( // 점수 범위의 제거 진행
+                    key,  // 대상 키값으로
+                    Double.NEGATIVE_INFINITY, // 음수 끝 ~ 9초 이전 값
+                    Instant.now().minusSeconds(PING_INTERNAL_SECONDS * PING_FAILURE_THRESHOLD).toEpochMilli());
+            return null;
+        });
+    }
+
+    @PreDestroy
+    public void leave() {
+        redisTemplate.opsForZSet().remove(generateKey(), APP_ID);
+    }
+
+    private String generateKey() {
+        return "message-relay-coordinator::app-list::%s".formatted(applicationName);
+    }
+}

--- a/src/main/java/app/slicequeue/sq_user/common/outbox_relay/Outbox.java
+++ b/src/main/java/app/slicequeue/sq_user/common/outbox_relay/Outbox.java
@@ -1,6 +1,5 @@
-package app.slicequeue.sq_user.common.outbox_message;
+package app.slicequeue.sq_user.common.outbox_relay;
 
-import app.slicequeue.sq_user.common.converter.MapToJsonConverter;
 import app.slicequeue.sq_user.common.event.EventType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -8,7 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.Instant;
-import java.util.Map;
 
 @Table(name = "outbox")
 @Getter
@@ -21,10 +19,17 @@ public class Outbox {
     private OutboxId outboxId;
     @Enumerated(EnumType.STRING)
     private EventType eventType;
-    @Convert(converter = MapToJsonConverter.class)
-    @Column(name = "payload_json")
-    private Map<String, Object> payload;
-    private Long targetId;
+    private String payload;
+    private Long shardKey;
     private Instant createdAt;
 
+    public static Outbox create(EventType eventType, String payload, Long shardKey) {
+        Outbox outbox = new Outbox();
+        outbox.outboxId = OutboxId.generateId();
+        outbox.eventType = eventType;
+        outbox.payload = payload;
+        outbox.shardKey = shardKey;
+        outbox.createdAt = Instant.now();
+        return outbox;
+    }
 }

--- a/src/main/java/app/slicequeue/sq_user/common/outbox_relay/OutboxEvent.java
+++ b/src/main/java/app/slicequeue/sq_user/common/outbox_relay/OutboxEvent.java
@@ -1,0 +1,16 @@
+package app.slicequeue.sq_user.common.outbox_relay;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class OutboxEvent {
+    private Outbox outbox;
+
+    public static OutboxEvent of(Outbox outbox) {
+        OutboxEvent outboxEvent = new OutboxEvent();
+        outboxEvent.outbox = outbox;
+        return outboxEvent;
+    }
+}

--- a/src/main/java/app/slicequeue/sq_user/common/outbox_relay/OutboxEventPublisher.java
+++ b/src/main/java/app/slicequeue/sq_user/common/outbox_relay/OutboxEventPublisher.java
@@ -1,0 +1,25 @@
+package app.slicequeue.sq_user.common.outbox_relay;
+
+import app.slicequeue.common.snowflake.Snowflake;
+import app.slicequeue.sq_user.common.event.Event;
+import app.slicequeue.sq_user.common.event.EventPayload;
+import app.slicequeue.sq_user.common.event.EventType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OutboxEventPublisher {
+    private final Snowflake outboxIdSnowflake = new Snowflake();
+    private final Snowflake eventIdSnowflake = new Snowflake();
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public void publish(EventType type, EventPayload payload, Long shardKey) {
+        Outbox outbox = Outbox.create(
+                type,
+                Event.of(eventIdSnowflake.nextId(), type, payload).toJson(),
+                shardKey % MessageRelayConstants.SHARD_COUNT);
+        applicationEventPublisher.publishEvent(OutboxEvent.of(outbox));
+    }
+}

--- a/src/main/java/app/slicequeue/sq_user/common/outbox_relay/OutboxId.java
+++ b/src/main/java/app/slicequeue/sq_user/common/outbox_relay/OutboxId.java
@@ -1,4 +1,4 @@
-package app.slicequeue.sq_user.common.outbox_message;
+package app.slicequeue.sq_user.common.outbox_relay;
 
 import app.slicequeue.common.base.id_entity.BaseSnowflakeId;
 import app.slicequeue.common.snowflake.Snowflake;

--- a/src/main/java/app/slicequeue/sq_user/common/outbox_relay/OutboxRepository.java
+++ b/src/main/java/app/slicequeue/sq_user/common/outbox_relay/OutboxRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -12,7 +13,7 @@ public interface OutboxRepository extends JpaRepository<Outbox, Long> {
 
     List<Outbox> findAllByShardKeyAndCreatedAtLessThanEqualOrderByCreatedAtAsc(
             Long shardKey,
-            LocalDateTime createdAt,
+            Instant createdAt,
             Pageable pageable
     );
 }

--- a/src/main/java/app/slicequeue/sq_user/common/outbox_relay/OutboxRepository.java
+++ b/src/main/java/app/slicequeue/sq_user/common/outbox_relay/OutboxRepository.java
@@ -1,0 +1,18 @@
+package app.slicequeue.sq_user.common.outbox_relay;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface OutboxRepository extends JpaRepository<Outbox, Long> {
+
+    List<Outbox> findAllByShardKeyAndCreatedAtLessThanEqualOrderByCreatedAtAsc(
+            Long shardKey,
+            LocalDateTime createdAt,
+            Pageable pageable
+    );
+}

--- a/src/main/java/app/slicequeue/sq_user/common/util/DataSerializer.java
+++ b/src/main/java/app/slicequeue/sq_user/common/util/DataSerializer.java
@@ -8,6 +8,8 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Map;
+
 @Slf4j
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class DataSerializer {
@@ -39,5 +41,9 @@ public final class DataSerializer {
             log.error("[DataSerializer.serialize] data={}", object, e);
             return null;
         }
+    }
+
+    public static Map<String, Object> serializeToMap(Object object) {
+        return objectMapper.convertValue(object, Map.class);
     }
 }

--- a/src/main/java/app/slicequeue/sq_user/common/util/DataSerializer.java
+++ b/src/main/java/app/slicequeue/sq_user/common/util/DataSerializer.java
@@ -1,0 +1,43 @@
+package app.slicequeue.sq_user.common.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class DataSerializer {
+    private static final ObjectMapper objectMapper = initialize();
+
+    private static ObjectMapper initialize() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    public static <T> T deserialize(String data, Class<T> clazz) {
+        try {
+            return objectMapper.readValue(data, clazz);
+        } catch (JsonProcessingException e) {
+            log.error("[DataSerializer.deserialize] data={}, clazz={}", data, clazz, e);
+            return null;
+        }
+    }
+
+    public static <T> T deserialize(Object data, Class<T> clazz) {
+        return objectMapper.convertValue(data, clazz);
+    }
+
+    public static String serialize(Object object) {
+        try {
+            return objectMapper.writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            log.error("[DataSerializer.serialize] data={}", object, e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/app/slicequeue/sq_user/user/command/application/usecase/UpdateUserInfoUseCase.java
+++ b/src/main/java/app/slicequeue/sq_user/user/command/application/usecase/UpdateUserInfoUseCase.java
@@ -1,0 +1,40 @@
+package app.slicequeue.sq_user.user.command.application.usecase;
+
+import app.slicequeue.sq_user.common.event.EventType;
+import app.slicequeue.sq_user.common.event.payload.UserInfoChangedEventPayload;
+import app.slicequeue.sq_user.common.outbox_relay.OutboxEventPublisher;
+import app.slicequeue.sq_user.user.command.application.service.UpdateUserService;
+import app.slicequeue.sq_user.user.command.domain.User;
+import app.slicequeue.sq_user.user.command.domain.UserId;
+import app.slicequeue.sq_user.user.command.domain.dto.UpdateUserCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateUserInfoUseCase {
+
+    private final UpdateUserService updateUserService;
+    private final OutboxEventPublisher outboxEventPublisher;
+
+    @Transactional
+    public UserId execute(UpdateUserCommand command) {
+        // 사용자 정보 수정
+        User user = updateUserService.updateUser(command);
+        // 이벤트 발행
+        outboxEventPublisher.publish(
+                EventType.USER_INFO_CHANGED,
+                UserInfoChangedEventPayload.builder()
+                        .userId(user.getUserId().getId())
+                        .projectId(user.getProjectId())
+                        .state(user.getState())
+                        .loginId(user.getLoginId())
+                        .nickname(user.getNickname())
+                        .profile(user.getProfile())
+                        .build(),
+                user.getProjectId());
+        return user.getUserId();
+    }
+
+}

--- a/src/main/java/app/slicequeue/sq_user/user/command/presentation/UserCommandController.java
+++ b/src/main/java/app/slicequeue/sq_user/user/command/presentation/UserCommandController.java
@@ -3,6 +3,7 @@ package app.slicequeue.sq_user.user.command.presentation;
 import app.slicequeue.common.dto.CommonResponse;
 import app.slicequeue.sq_user.user.command.application.service.CreateUserService;
 import app.slicequeue.sq_user.user.command.application.service.UpdateUserService;
+import app.slicequeue.sq_user.user.command.application.usecase.UpdateUserInfoUseCase;
 import app.slicequeue.sq_user.user.command.domain.UserId;
 import app.slicequeue.sq_user.user.command.domain.dto.CreateUserCommand;
 import app.slicequeue.sq_user.user.command.domain.dto.UpdateUserCommand;
@@ -17,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserCommandController {
 
     private final CreateUserService createUserService;
-    private final UpdateUserService updateUserService;
+    private final UpdateUserInfoUseCase updateUserInfoUseCase;
 
     @PostMapping
     public CommonResponse<String> create(@RequestBody @Valid UserRequest request) {
@@ -28,6 +29,6 @@ public class UserCommandController {
     @PutMapping("{userId}")
     public CommonResponse<String> update(@RequestBody @Valid UserRequest request, @PathVariable Long userId) {
         UpdateUserCommand command = UpdateUserCommand.from(request, UserId.from(userId));
-        return CommonResponse.success("updated.", updateUserService.updateUser(command).getUserId().toString());
+        return CommonResponse.success("updated.", updateUserInfoUseCase.execute(command).toString());
     }
 }

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+app.slicequeue.sq_user.common.outbox_relay.MessageRelayConfig

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,10 @@ spring:
     show-sql: true
     hibernate:
       ddl-auto: validate
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: sq-user-service
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      enable-auto-commit: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,12 @@ spring:
     show-sql: true
     hibernate:
       ddl-auto: validate
+  data:
+    redis:
+      host: ${REDIS_URL:localhost}
+      port: ${REDIS_PORT:6379}
+#      username: ${REDIS_USER}
+      password: ${REDIS_PASS} # 비밀번호만 사용
   kafka:
     bootstrap-servers: localhost:9092
     consumer:

--- a/src/main/resources/ddl/init.sql
+++ b/src/main/resources/ddl/init.sql
@@ -19,9 +19,9 @@ CREATE TABLE users (
 CREATE TABLE outbox (
   outbox_id BIGINT NOT NULL COMMENT '아웃박스 식별값',
   event_type VARCHAR(64) NOT NULL COMMENT '이벤트 유형',
-  payload_json JSON NOT NULL COMMENT '이벤트 송신 데이터 페이로드',
-  target_id BIGINT NOT NULL COMMENT '대상 식별값, 샤딩 대상',
+  shard_key BIGINT NOT NULL COMMENT '샤딩 키값, 이 값을 이용하여 인스턴스 마다 배정하여 처리함',
   created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '생성일시',
+  payload TEXT NOT NULL COMMENT '이벤트 송신 데이터 페이로드',
   PRIMARY KEY (outbox_id),
-  INDEX idx_shard_key_created_at (target_id, created_at))
+  INDEX idx_shard_key_created_at (shard_key, created_at))
 COMMENT = '이벤트 아웃박스';

--- a/src/main/resources/ddl/init.sql
+++ b/src/main/resources/ddl/init.sql
@@ -15,3 +15,13 @@ CREATE TABLE users (
   PRIMARY KEY (user_id),
   INDEX idx_project_id_state_login_id (project_id, state, login_id)
 ) COMMENT '사용자';
+
+CREATE TABLE outbox (
+  outbox_id BIGINT NOT NULL COMMENT '아웃박스 식별값',
+  event_type VARCHAR(64) NOT NULL COMMENT '이벤트 유형',
+  payload_json JSON NOT NULL COMMENT '이벤트 송신 데이터 페이로드',
+  target_id BIGINT NOT NULL COMMENT '대상 식별값, 샤딩 대상',
+  created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '생성일시',
+  PRIMARY KEY (outbox_id),
+  INDEX idx_shard_key_created_at (target_id, created_at))
+COMMENT = '이벤트 아웃박스';

--- a/src/test/java/app/slicequeue/sq_user/common/outbox_relay/AssignedShardTest.java
+++ b/src/test/java/app/slicequeue/sq_user/common/outbox_relay/AssignedShardTest.java
@@ -1,0 +1,41 @@
+package app.slicequeue.sq_user.common.outbox_relay;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class AssignedShardTest {
+
+    @Test
+    void ofTest() {
+        // given
+        long sharedCount = 64L;
+        List<String> appList = List.of("appId1", "appId2", "appId3");
+
+        // when
+        AssignedShard assignedShard1 = AssignedShard.of(appList.get(0), appList, sharedCount);
+        AssignedShard assignedShard2 = AssignedShard.of(appList.get(1), appList, sharedCount);
+        AssignedShard assignedShard3 = AssignedShard.of(appList.get(2), appList, sharedCount);
+        AssignedShard assignedShard4 = AssignedShard.of("invalid", appList, sharedCount);
+
+        // then
+        List<Long> result = Stream.of(
+                        assignedShard1.getShards(),
+                        assignedShard2.getShards(),
+                        assignedShard3.getShards(),
+                        assignedShard4.getShards()
+                ).flatMap(List::stream)
+                .toList();
+        assertThat(result).hasSize((int) sharedCount);
+
+        for (int i = 0; i < sharedCount; i++) {
+            assertThat(result.get(i)).isEqualTo(i);
+        }
+
+        assertThat(assignedShard4.getShards()).isEmpty();
+    }
+}


### PR DESCRIPTION
## 개요
- 아웃박스 패턴을 적용하여 메세지 릴레이 기능을 구현했습니다.
- 기존의 직접 이벤트 발송 방식에서 아웃박스를 통한 이벤트 발송 방식으로 전환하였습니다.

## 주요 변경 사항
- 아웃박스(Outbox) 테이블 및 엔티티 추가
- 이벤트 발생 시 아웃박스에 메시지 저장 로직 구현
- 별도 프로세스(스케줄러 등)를 통한 아웃박스 메시지 릴레이 기능 추가
- 기존 이벤트 발송 코드 리팩토링 및 아웃박스 연동

## 기대 효과
- 메세지 발송의 신뢰성 향상 (트랜잭션 처리 보장)
- 장애 상황에서의 재처리 용이성 확보

## 테스트
- 단위 테스트 및 통합 테스트를 통해 정상적으로 이벤트가 릴레이 되는지 검증 완료

## Next 🚀 
- [ ] https://github.com/slicequeue-system/sq-common-message-relay-starter 적용
